### PR TITLE
ci(config): Corrige le chemin du fichier d'environnement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,9 +47,9 @@ jobs:
       # Set environment variables
       - name: Create environment file
         run: |
-          mkdir -p environments
+          mkdir -p src/environments
           echo "Creating production environment file..."
-          echo "${{ secrets.FIREBASE_CONFIG }}" >> environments/environment.ts
+          echo "${{ secrets.FIREBASE_CONFIG }}" >> src/environments/environment.ts
 
       # Build
       - name: Build


### PR DESCRIPTION
Le dossier `src/environments` est désormais utilisé pour stocker le fichier d'environnement, conformément à la structure attendue. Cela corrige un problème potentiel lors de la configuration de l'environnement dans les workflows GitHub Actions.