### PR TITLE
ci(config): Modifie la branche principale de main à master

### DIFF
--- a/.github/workflows/manage-labels.yml
+++ b/.github/workflows/manage-labels.yml
@@ -3,7 +3,7 @@ name: "Synchronisation des Labels"
 on:
   push:
     branches:
-      - main
+      - master
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Cette correction met à jour la branche suivie dans le workflow GitHub Actions pour pointer sur master au lieu de main.