### PR TITLE
chore(dependencies): Update Angular build and Node.js version in CI w…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [22.13]
+        node-version: [22.14]
 
     steps:
       # Vérification du dépôt

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@angular-eslint/eslint-plugin-template": "^19.0.2",
     "@angular-eslint/schematics": "^19.0.2",
     "@angular-eslint/template-parser": "^19.0.2",
-    "@angular/build": "^19.1.6",
+    "@angular/build": "^19.1.7",
     "@angular/cli": "^19.1.6",
     "@angular/compiler-cli": "^19.1.4",
     "@types/jest": "^29.5.14",
@@ -59,6 +59,7 @@
     "stylelint-config-standard-scss": "^13.1.0",
     "ts-node": "^10.9.2",
     "typescript": "~5.5.2",
-    "typescript-eslint": "8.15.0"
+    "typescript-eslint": "8.15.0",
+    "@angular-builders/jest": "^19.0.1"
   }
 }


### PR DESCRIPTION
…orkflow

- Upgrade @angular/build to version 19.1.7
- Add @angular-builders/jest package
- Update Node.js version in CI workflow from 22.13 to 22.14