### PR TITLE
chore(config): Autorise `console.log` dans les règles ESLint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -42,7 +42,7 @@
         "@typescript-eslint/no-explicit-any": "off",
         "no-unused-vars": "off",
         "@typescript-eslint/no-unused-vars": "error",
-        "no-console": ["error", { "allow": ["warn", "error"] }],
+        "no-console": ["error", { "allow": ["warn", "error", "log"] }],
         "linebreak-style": ["error", "unix"],
         "@typescript-eslint/no-non-null-assertion": "error",
         "@angular-eslint/directive-selector": [


### PR DESCRIPTION
- Modifie la configuration ESLint pour permettre l'utilisation de `console.log` en plus de `console.warn` et `console.error`.
- Garantit plus de flexibilité pour le débogage pendant le développement.