### PR TITLE
refactor(service:auth): Implémente un pattern Port/Adapter

### DIFF
--- a/src/app/core/adapter/authentication-firebase.service.ts
+++ b/src/app/core/adapter/authentication-firebase.service.ts
@@ -5,8 +5,8 @@ import {
   AuthenticationService,
   LoginResponse,
   RegisterResponse,
-} from './authentication.service';
-import { environment } from '../../environments/environment';
+} from '../port/authentication.service';
+import { environment } from '../../../environments/environment';
 
 /**
  * Represents the payload of the response received when registering a new user in Firebase.
@@ -66,26 +66,4 @@ export class AuthenticationFirebaseService implements AuthenticationService {
       })),
     );
   }
-
-  /*save(
-    email: string,
-    userId: string,
-    bearerToken: string,
-  ): Observable<unknown> {
-    const baseUrl = `https://firestore.googleapis.com/v1/projects/${environment.firebase.projectId}/databases/(default)/documents`;
-    const userFirestoreCollectionId = 'users';
-    const url = `${baseUrl}/${userFirestoreCollectionId}?key=${environment.firebase.apiKey}&documentId=${userId}`;
-    const body = {
-      fields: {
-        email: { stringValue: email },
-      },
-    };
-
-    const headers = new HttpHeaders({
-      Authorization: `Bearer ${bearerToken}`,
-    });
-    const options = { headers };
-
-    return this.#http.post(url, body, options);
-  }*/
 }

--- a/src/app/core/port/authentication.service.ts
+++ b/src/app/core/port/authentication.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
+import { AuthenticationFirebaseService } from '../adapter/authentication-firebase.service';
 
 export interface RegisterResponse {
   jwtToken: string;
@@ -16,7 +17,10 @@ export interface LoginResponse {
   isRegistered: boolean;
 }
 
-@Injectable()
+@Injectable({
+  providedIn: 'root',
+  useClass: AuthenticationFirebaseService,
+})
 export abstract class AuthenticationService {
   abstract register(
     email: string,


### PR DESCRIPTION
- Ajoute un service Firebase comme implémentation par défaut via `useClass`.
- Déplace `AuthenticationService` dans un dossier de portage logique.
- Améliore la clarté et la conformité du code avec le pattern.