### PR TITLE
fix(service:api): Corrige l'utilisation des backticks pour l'URL Fire…

### DIFF
--- a/src/app/core/adapter/user-firebase.service.ts
+++ b/src/app/core/adapter/user-firebase.service.ts
@@ -8,8 +8,7 @@ import { User } from '../entity/user.interface';
 @Injectable()
 export class UserFirebaseService implements UserService {
   readonly #http = inject(HttpClient);
-  readonly #FIRESTORE_URL =
-    'https://firestore.googleapis.com/v1/projects/${environment.firebase.projectId}/databases/(default)/documents';
+  readonly #FIRESTORE_URL = `https://firestore.googleapis.com/v1/projects/${environment.firebase.projectId}/databases/(default)/documents`;
   readonly #USER_COLLECTION_ID = 'users';
   readonly #FIREBASE_API_KEY = environment.firebase.apiKey;
   readonly #USER_COLLECTION_URL = `${this.#FIRESTORE_URL}/${this.#USER_COLLECTION_ID}?key=${this.#FIREBASE_API_KEY}&documentId=`;


### PR DESCRIPTION
…store

- Remplace les apostrophes simples par des backticks pour permettre l'interpolation de variables dans l'URL FIRESTORE.
- Garantit le fonctionnement correct lors de l'utilisation de `environment.firebase.projectId`.