### PR TITLE
ci: Corrige la commande de test dans le workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
 
       # Tests
       - name: Test
-        run: pnpm test
+        run: pnpm run test
 
       # Set environment variables
       - name: Create environment file


### PR DESCRIPTION
- Remplace `pnpm test` par `pnpm run test` pour assurer la bonne exécution des tests.
- Cette modification corrige une erreur dans le workflow CI.