### PR TITLE
feat(service:store): Intègre un cas d'utilisation pour l'enregistreme…

### DIFF
--- a/src/app/core/use-case/register-user.use-case.service.spec.ts
+++ b/src/app/core/use-case/register-user.use-case.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { RegisterUserUseCaseService } from './register-user.use-case.service';
+
+describe('RegisterUserUseCaseService', () => {
+  let service: RegisterUserUseCaseService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(RegisterUserUseCaseService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/core/use-case/register-user.use-case.service.ts
+++ b/src/app/core/use-case/register-user.use-case.service.ts
@@ -1,0 +1,32 @@
+import { inject, Injectable } from '@angular/core';
+import { User, Visitor } from '../entity/user.interface';
+import { AuthenticationService } from '../port/authentication.service';
+import { firstValueFrom } from 'rxjs';
+import { UserService } from '../port/user.service';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class RegisterUserUseCaseService {
+  readonly #authenticationService = inject(AuthenticationService);
+  readonly #userService = inject(UserService);
+  async execute(visitor: Visitor): Promise<User> {
+    const response = await firstValueFrom(
+      this.#authenticationService.register(visitor.email, visitor.password),
+    );
+
+    localStorage.setItem('jwtToken', response.jwtToken);
+    localStorage.setItem('jwtRefreshToken', response.jwtRefreshToken);
+    localStorage.setItem('expiresIn', response.expiresIn);
+
+    const user: User = {
+      id: response.userId,
+      name: visitor.name,
+      email: visitor.email,
+    };
+
+    await this.#userService.create(user, response.jwtToken);
+
+    return user;
+  }
+}


### PR DESCRIPTION
…nt utilisateur

- Ajoute `RegisterUserUseCaseService` pour centraliser la logique d'enregistrement utilisateur.
- Remplace l'implémentation directe dans `UserStore` par une utilisation du service dédié.