### PR TITLE
fix(component:navbar): Corrige le lien Connexion avec routerLink

### DIFF
--- a/setup-jest.ts
+++ b/setup-jest.ts
@@ -1,1 +1,3 @@
-import 'jest-preset-angular/setup-jest';
+import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
+
+setupZoneTestEnv();

--- a/src/app/core/component/navbar/navbar.smart.component.html
+++ b/src/app/core/component/navbar/navbar.smart.component.html
@@ -18,7 +18,9 @@
     <div class="collapse navbar-collapse" id="navbarSupportedContent">
       <ul class="navbar-nav ms-auto mb-2 mb-lg-0">
         <li class="nav-item">
-          <a class="nav-link active" aria-current="page" href="#">Connexion</a>
+          <a class="nav-link active" aria-current="page" routerLink="/login"
+            >Connexion</a
+          >
         </li>
         <li class="nav-item">
           <a class="nav-link active" aria-current="page" routerLink="/signup">

--- a/tsconfig.spec.json
+++ b/tsconfig.spec.json
@@ -5,8 +5,7 @@
   "compilerOptions": {
     "outDir": "./out-tsc/spec",
     "types": ["jest"],
-    "esModuleInterop": true,
-    "emitDecoratorMetadata": true
+    "esModuleInterop": true
   },
   "include": [
     "src/**/*.spec.ts",


### PR DESCRIPTION
- Mise à jour du lien de navigation pour utiliser `routerLink` au lieu de `href` dans le composant Navbar.
- Ajuste la configuration de Jest pour inclure `setupZoneTestEnv`.
- Supprime l'option superflue `emitDecoratorMetadata` du fichier `tsconfig.spec.json`.